### PR TITLE
Updating MNIST container name.

### DIFF
--- a/mnist/platforms/docker.yaml
+++ b/mnist/platforms/docker.yaml
@@ -1,6 +1,8 @@
+schema_type: mlcommons_box_platform
+schema_version: 0.1.0
+
 platform:
   name: "docker"
-  version: ">=19.03.9"
-
+  version: ">=18.01"
 container:
-  image: "serebrya/mlperf-mnist:0.0.1"
+  image: "serebrya/mlbox_mnist:0.0.2"


### PR DESCRIPTION
Renaming from `serebrya/mlperf-mnist:0.0.1` to `serebrya/mlbox_mnist:0.0.2`.