### PR TITLE
Remove unused function from mnist example

### DIFF
--- a/mnist/build/mnist.py
+++ b/mnist/build/mnist.py
@@ -25,12 +25,7 @@ class Task(str, Enum):
     DownloadData = 'download'
     Train = 'train'
 
-
-def create_directory(path: str) -> None:
-    if not os.path.exists(path):
-        os.makedirs(path, exist_ok=True)
-
-
+    
 def download(task_args: List[str]) -> None:
     """ Task: download.
     Input parameters:


### PR DESCRIPTION
While reading the example I couldn't find any use of the `create_directory` function so this PR proposes to remove it.