### PR TITLE
Updating MNIST mlcube.yaml

### DIFF
--- a/mnist/.dockerignore
+++ b/mnist/.dockerignore
@@ -1,1 +1,6 @@
+# Ignore everything in workspace directory
 workspace/
+
+# except these two configuration files
+!/workspace/data.yaml
+!/workspace/train.yaml

--- a/mnist/Dockerfile
+++ b/mnist/Dockerfile
@@ -19,4 +19,9 @@ COPY requirements.txt /requirements.txt
 RUN pip3 install --no-cache-dir -r /requirements.txt
 
 COPY mnist.py /workspace/mnist.py
+
+COPY mlcube.yaml /mlcube/mlcube.yaml
+COPY workspace/data.yaml /mlcube/workspace/data.yaml
+COPY workspace/train.yaml /mlcube/workspace/train.yaml
+
 ENTRYPOINT ["python3", "/workspace/mnist.py"]

--- a/mnist/README.md
+++ b/mnist/README.md
@@ -1,38 +1,34 @@
 # MNIST MLCube
 
-Proof-of-concept for MLCube configuration 2.0. Please, review the following:
+This example MLCube trains a simple neural network using MNIST dataset. Concretely, it implements two tasks:
 
-1. Local user configuration for docker (and other) runtime: [.mlcube.yaml](../.mlcube.yaml). This file here is for
-   example, and is not shipped with MLCubes in general. It contains common options for MLCube execution environments
-   common to all MLCubes. 
-2. New MLCube configuration file 2.0 [mlcube.yaml](../mlcube.py)
-3. The [mlcube.py](../mlcube.py) here simulates MLCube CLI. It is temporary stored here, and is part of MLCube library.
+- `download` task downloads MNIST dataset.
+- `train` trains a DL model.
 
-This modified MNIST example depends on latest version of docker runner located in this branch:
-```
-https://github.com/sergey-serebryakov/mlbox/tree/feature/configV2
-```
-
-I do not think it's worth spending time now trying to reproduce results, but in case it's required:
-1. Clone that branch.
-2. Create virtual environment with python >= 3.6.
-3. Export PYTHONPATH variable. Only mlcube_docker is requried to be present.
-4. Install mlcube dependencies (mlcube/requirements.txt) and omegaconf
-5. Run this example:
-   ```bash
-   python mlcube.py show_config --mlcube=./mnist --platform=docker --resolve
-   python mlcube.py run --mlcube ./mnist --task download --platform docker
-   python mlcube.py run --mlcube ./mnist --task train --platform docker
-   ```
-
-The example implementation uses OmegaConf, so users can use configuration variables:
 ```shell
-$ mlcube run ... --workspace=/nfs/workspace/mnist
-# workspace: /nfs/workspace/mnist
+# Create python virtual environment
+virtualenv -p python3 ./env && source ./env/bin/activate
 
-$ mlcube run ... --workspace='/nfs/workspace/${name}'
-# workspace: /nfs/workspace/mnist
+# Install MLCube and MLCube docker/singularity runners
+pip install mlcube mlcube-docker mlcube-singularity
 
-$ mlcube run ... --workspace='~/.mlcube/workspace/${name}'
-# workspace: /home/developer/.mlcube/workspace/mnist
+# Show installed MLCube runners
+mlcube config --get runners
+
+# Show platform configurations. A platform is a configured instance of a runner.
+mlcube config --get platforms
+
+# Clone MLCube examples and go to MNIST root directory
+git clone https://github.com/mlcommons/mlcube_examples.git && cd ./mlcube_examples/mnist
+
+# Show MLCube overview
+mlcube describe --mlcube .
+
+# Show MLCube and MLCube docker and singularity configurations
+mlcube show_config --resolve --mlcube . --platform docker
+mlcube show_config --resolve --mlcube . --platform singularity
+
+# Download data and train a model using default docker platform.
+mlcube run --mlcube . --task download --platform docker
+mlcube run --mlcube . --task train --platform docker
 ```

--- a/mnist/Singularity.recipe
+++ b/mnist/Singularity.recipe
@@ -24,5 +24,9 @@ From: ubuntu:18.04
     requirements.txt /requirements.txt
     mnist.py /workspace/mnist.py
 
+    mlcube.yaml /mlcube/mlcube.yaml
+    workspace/data.yaml /mlcube/workspace/data.yaml
+    workspace/train.yaml /mlcube/workspace/train.yaml
+
 %runscript
     python /workspace/mnist.py "$@"

--- a/mnist/mlcube.yaml
+++ b/mnist/mlcube.yaml
@@ -15,7 +15,7 @@ docker:
   image: mlcommons/mnist:0.0.1
 
 singularity:
-  image: mnist-0.0.1.simg
+  image: mnist-0.0.1.sif
 
 tasks:
   download:


### PR DESCRIPTION
1. Updating docker and singularity recipes. They copy MLCube configuration (mlcube.yaml) and parameter files (workspace/data.yaml, workspace/train.yaml) into docker and singularity images. New versions of MLCube runners will support running MLCubes in cases when `--mlcube` points to something different than local path, such as docker and singularity containers.

2. Rewriting README.md file.

3. Updating mnist/.dockerignore file to allow sending parameter files from workspace to docker context.

4. Changing extenstion of the MNIST singularity image from `simg` to `sif`.