### PR TITLE
Upgrade base image to fix issue with get-pip.py

### DIFF
--- a/emdenoise/Dockerfile
+++ b/emdenoise/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER MLPerf MLBox Working Group
 
 # Remove all stopped containers: docker rm $(docker ps -a -q)

--- a/hello_world/Dockerfile
+++ b/hello_world/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER MLPerf MLBox Working Group
 
 RUN apt-get update && \

--- a/matmul/Dockerfile
+++ b/matmul/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER MLPerf MLBox Working Group
 
 # Remove all stopped containers: docker rm $(docker ps -a -q)

--- a/mnist/Dockerfile
+++ b/mnist/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER MLPerf MLBox Working Group
 
 # Remove all stopped containers: docker rm $(docker ps -a -q)

--- a/mnist_fl/pytorch/build/Dockerfile
+++ b/mnist_fl/pytorch/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL MLPerf MLBox Working Group
 
 RUN apt-get update && \

--- a/mnist_fl/tensorflow/build/Dockerfile
+++ b/mnist_fl/tensorflow/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL MLPerf MLBox Working Group
 
 RUN apt-get update && \


### PR DESCRIPTION
Currently all cubes will break when trying to install pip using `get-pip.py`. The reason for this is that `get-pip.py` has dropped compatibility with Python 3.**6** (see [here](https://pip.pypa.io/en/stable/installation/#compatibility)) which is default installed version of the `python3` package in Ubuntu 18.04. Using the Ubuntu 20.04 base image will resolve this issue.

The error which will otherwise be thrown in the `docker build` process is:

```
 => ERROR [3/6] RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py &&     python3 get-pip.py &&     rm get-pip.py                                                                            0.8s
------
 > [3/6] RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py &&     python3 get-pip.py &&     rm get-pip.py:
#6 0.753 ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.
```