### PR TITLE
Fixing pip version for MNIST example MLCube.

### DIFF
--- a/mnist/Dockerfile
+++ b/mnist/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && \
             curl && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+# Ubuntu 18.04 provides python 3.6
+RUN curl -fSsL -O https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
     python3 get-pip.py && \
     rm get-pip.py
 


### PR DESCRIPTION
Base docker image (`ubuntu:18.04`) provides python 3.6. Latest versions of pip require python >= 3.7. This bug fix sets pip version to python 3.6 in docker file.