### PR TITLE
Bugfix/mnist singularity

### DIFF
--- a/emdenoise/Dockerfile
+++ b/emdenoise/Dockerfile
@@ -8,20 +8,21 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
             software-properties-common \
             python3-dev \
-	    wget \
-	    cmake \
-	    g++-4.8 \
-	    git \
-	    vim \
- 	    ca-certificates \
-	    libibverbs1 \
-	    librdmacm1 \
+            wget \
+            cmake \
+            g++-4.8 \
+            git \
+            vim \
+            ca-certificates \
+            libibverbs1 \
+            librdmacm1 \
       	    ibverbs-providers \
-	    build-essential \
+            build-essential \
             curl && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
+# Ubuntu 18.04 provides python 3.6
+RUN curl -fSsL -O https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
     python3 get-pip.py && \
     rm get-pip.py
 
@@ -30,7 +31,7 @@ RUN mkdir /tmp/openmpi && \
     cd /tmp/openmpi && \
     wget https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.0.tar.gz && \
     tar zxf openmpi-4.0.0.tar.gz && \
-    cd openmpi-4.0.0 && \    
+    cd openmpi-4.0.0 && \
     ./configure --enable-orterun-prefix-by-default && \
     make -j $(nproc) all && \
     make install && \

--- a/mnist/Singularity.recipe
+++ b/mnist/Singularity.recipe
@@ -13,8 +13,8 @@ From: ubuntu:18.04
     rm -rf /var/lib/apt/lists/*
     ln -s /usr/bin/python3 /usr/local/bin/python
 
-    # Install latest pip3 package, 'setuptools' and 'wheel'.
-    curl -fSsL -O https://bootstrap.pypa.io/get-pip.py
+    # Install latest pip3 package for Ubuntu 18:04, 'setuptools' and 'wheel'.
+    curl -fSsL -O https://bootstrap.pypa.io/pip/3.6/get-pip.py
     python3 get-pip.py
     rm get-pip.py
 


### PR DESCRIPTION
Base docker image (ubuntu:18.04) provides python 3.6. Latest versions of pip require python >= 3.7. This bug fix sets pip version to python 3.6 in Singularity.recipe.