### PR TITLE
Updating MLCube configuration files.

### DIFF
--- a/emdenoise/mlcube.yaml
+++ b/emdenoise/mlcube.yaml
@@ -12,16 +12,31 @@ docker:
 tasks:
   download:
     parameters:
-      outputs: {raw_data_dir: raw_data/, log_dir: logs/}
+      outputs:
+        raw_data_dir: {type: directory, default: raw_data}
+        log_dir: {type: directory, default: logs}
   preprocess:
     parameters:
-      inputs: {raw_data_dir: raw_data/}
-      outputs: {data_dir: data/, log_dir: logs/}
+      inputs:
+        raw_data_dir: {type: directory, default: raw_data}
+      outputs:
+        data_dir: {type: directory, default: data}
+        log_dir: {type: directory, default: logs}
   train:
     parameters:
-      inputs: {data_dir: data/, parameters_file: parameters/default.parameters.yaml}
-      outputs: {model_dir: model/, output_dir: output/, log_dir: logs/}
+      inputs:
+        data_dir: {type: directory, default: data}
+        parameters_file: {type: file, default: parameters/default.parameters.yaml}
+      outputs:
+        model_dir: {type: directory, default: model}
+        output_dir: {type: directory, default: output}
+        log_dir: {type: directory, default: logs}
   test:
     parameters:
-      inputs: {data_dir: data/, model_dir: model/, parameters_file: parameters/default.parameters.yaml}
-      outputs: {output_dir: output/, log_dir: logs/}
+      inputs:
+        data_dir: {type: directory, default: data}
+        model_dir: {type: directory, default: model}
+        parameters_file: {type: file, default: parameters/default.parameters.yaml}
+      outputs:
+        output_dir: {type: directory, default: output}
+        log_dir: {type: directory, default: logs}

--- a/matmul/mlcube.yaml
+++ b/matmul/mlcube.yaml
@@ -12,5 +12,7 @@ docker:
 tasks:
   matmul:
     parameters:
-      inputs: {parameters_file: shapes.yaml}
-      outputs: {output_file: {type: file, default: matmul.txt}}
+      inputs:
+        parameters_file: {type: file, default: shapes.yaml}
+      outputs:
+        output_file: {type: file, default: matmul.txt}

--- a/mnist/mlcube.yaml
+++ b/mnist/mlcube.yaml
@@ -20,9 +20,16 @@ singularity:
 tasks:
   download:
     parameters:
-      inputs: {data_config: data.yaml}
-      outputs: {data_dir: data/, log_dir: logs/}
+      inputs:
+        data_config: {type: file, default: data.yaml}
+      outputs:
+        data_dir: {type: directory, default: data}
+        log_dir: {type: directory, default: logs}
   train:
     parameters:
-      inputs: {data_dir: data/, train_config: train.yaml}
-      outputs: {log_dir: logs/, model_dir: model/}
+      inputs:
+        data_dir: {type: directory, default: data}
+        train_config: {type: file, default: train.yaml}
+      outputs:
+        log_dir: {type: directory, default: logs}
+        model_dir: {type: directory, default: model}

--- a/mnist_fl/pytorch/mlcube.yaml
+++ b/mnist_fl/pytorch/mlcube.yaml
@@ -22,10 +22,21 @@ tasks:
   train:
   # Train model
     parameters:
-      inputs: {data_dir: data/, parameters_file: parameters/default.parameters.yaml, model_in: model/}
-      outputs: {log_dir: train_logs/, metrics: {type: file, default: metrics/train_metrics.json}, model_dir: model/}
+      inputs:
+        data_dir: {type: directory, default: data}
+        parameters_file: {type: file, default: parameters/default.parameters.yaml}
+        model_in: {type: directory, default: model}
+      outputs:
+        log_dir: {type: directory, default: train_logs}
+        metrics: {type: file, default: metrics/train_metrics.json}
+        model_dir: {type: directory, default: model}
   evaluate:
   # evaluate model
     parameters:
-      inputs: {data_dir: data/, parameters_file: parameters/default.parameters.yaml, model_in: model/}
-      outputs: {log_dir: evaluate_logs/, metrics: {type: file, default: metrics/evaluate_metrics.json}}
+      inputs:
+        data_dir: {type: directory ,default: data}
+        parameters_file: {type: file, default: parameters/default.parameters.yaml}
+        model_in: {type: directory, default: model}
+      outputs:
+        log_dir: {type: directory, default: evaluate_logs}
+        metrics: {type: file, default: metrics/evaluate_metrics.json}

--- a/mnist_fl/tensorflow/mlcube.yaml
+++ b/mnist_fl/tensorflow/mlcube.yaml
@@ -22,10 +22,21 @@ tasks:
   train:
   # Train model
     parameters:
-      inputs: {data_dir: data/, parameters_file: parameters/default.parameters.yaml, model_in: model/}
-      outputs: {log_dir: train_logs/, metrics: {type: file, default: metrics/train_metrics.json}, model_dir: model/}
+      inputs:
+        data_dir: {type: directory, default: data}
+        parameters_file: {type: file, default: parameters/default.parameters.yaml}
+        model_in: {type: directory, default: model}
+      outputs:
+        log_dir: {type: directory, default: train_logs}
+        metrics: {type: file, default: metrics/train_metrics.json}
+        model_dir: {type: directory, default: model}
   evaluate:
   # evaluate model
     parameters:
-      inputs: {data_dir: data/, parameters_file: parameters/default.parameters.yaml, model_in: model/}
-      outputs: {log_dir: evaluate_logs/, metrics: {type: file, default: metrics/evaluate_metrics.json}}
+      inputs:
+        data_dir: {type: directory, default: data}
+        parameters_file: {type: file, default: parameters/default.parameters.yaml}
+        model_in: {type: directory, default: model}
+      outputs:
+        log_dir: {type: directory, default: evaluate_logs}
+        metrics: {type: file, default: metrics/evaluate_metrics.json}


### PR DESCRIPTION
With recent and upcoming changes in MLCube runtime to support Windows OS, we came to conclusion that we need to specify input and output parameters using the full format (the one that includes parameter `type` (file/directory) explicitly). This commit introduces these changes to all MLCube example projects in this repository.