### PR TITLE
Returning proper exit codes when MLCubes fail.

### DIFF
--- a/emdenoise/main.py
+++ b/emdenoise/main.py
@@ -1,4 +1,6 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
+
+import sys
 from abc import (abstractmethod, ABC)
 import time
 import h5py
@@ -557,6 +559,7 @@ def main():
             raise ValueError(f"Unknown task: {task_args}")
     except Exception as err:
         logger.exception(err)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/mnist_fl/pytorch/build/mnist.py
+++ b/mnist_fl/pytorch/build/mnist.py
@@ -370,6 +370,7 @@ def main():
             raise ValueError(f"Unknown task: {task_args}")
     except Exception as err:
         logger.exception(err)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/mnist_fl/tensorflow/build/mnist.py
+++ b/mnist_fl/tensorflow/build/mnist.py
@@ -4,6 +4,7 @@ https://www.tensorflow.org/tutorials/quickstart/beginner
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import sys
 import argparse
 import json
 import logging
@@ -276,6 +277,7 @@ def main():
             raise ValueError(f"Unknown task: {task_args}")
     except Exception as err:
         logger.exception(err)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In EMDenoise and PyTorch/TensorFlow MNISTFL projects the main functions catch exceptions and print them on a console without returning proper exit codes (e.g., 1). This commit fixes this by calling `sys.exit` with error code equal to 1.