### PR TITLE
[WIP] Add gpus example

### DIFF
--- a/gpus/.dockerignore
+++ b/gpus/.dockerignore
@@ -1,0 +1,1 @@
+workspace/

--- a/gpus/.gitignore
+++ b/gpus/.gitignore
@@ -1,0 +1,1 @@
+/workspace

--- a/gpus/Dockerfile
+++ b/gpus/Dockerfile
@@ -1,0 +1,8 @@
+FROM nvidia/cuda:11.0-base
+
+# Copy code
+COPY . /workspace
+RUN chmod +x /workspace/*.sh
+
+# Set working directory
+WORKDIR /workspace

--- a/gpus/Dockerfile
+++ b/gpus/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.0-base
+FROM nvidia/cuda:11.6.1-base-ubuntu20.04
 
 # Copy code
 COPY . /workspace

--- a/gpus/README.md
+++ b/gpus/README.md
@@ -10,7 +10,7 @@ virtualenv -p python3 ./env && source ./env/bin/activate && pip install mlcube-d
 # Fetch the gpus example from GitHub
 git clone https://github.com/mlcommons/mlcube_examples && cd ./mlcube_examples
 git fetch origin pull/68/head:feature/gpu_example && git checkout feature/gpu_example
-cd ./gpu_example/
+cd ./gpus/
 ```
 
 ## MLCube tasks

--- a/gpus/README.md
+++ b/gpus/README.md
@@ -1,0 +1,38 @@
+# GPUs example
+
+## Project setup
+
+An important requirement is that you must have Docker and/or Singularity installed.
+
+```bash
+# Create Python environment and install MLCube with runners 
+virtualenv -p python3 ./env && source ./env/bin/activate && pip install mlcube-docker mlcube-singularity
+# Fetch the gpus example from GitHub
+git clone https://github.com/mlcommons/mlcube_examples && cd ./mlcube_examples
+git fetch origin pull/xxx/head:feature/gpu_example && git checkout feature/gpu_example
+cd ./gpu_example/
+```
+
+## MLCube tasks
+
+There is only one taks that will output the variable `CUDA_VISIBLE_DEVICES` along with the ouput of the `nvidia-smi` command:
+
+```shell
+mlcube run --task=check_gpus
+```
+
+You can modify the number of gpus by editing the number of `accelerator_count` inside the **mlcube.yaml** file.
+
+Also you can override the number of gpus to use by using the `--gpus` flag when running the command, example:
+
+```shell
+mlcube run --task=check_gpus --gpus=2
+```
+
+### Singularity
+
+For running on Singularity, you can define the platform while running the command as follows:
+
+```shell
+mlcube run --task=check_gpus --platform=singularity
+```

--- a/gpus/README.md
+++ b/gpus/README.md
@@ -9,7 +9,7 @@ An important requirement is that you must have Docker and/or Singularity install
 virtualenv -p python3 ./env && source ./env/bin/activate && pip install mlcube-docker mlcube-singularity
 # Fetch the gpus example from GitHub
 git clone https://github.com/mlcommons/mlcube_examples && cd ./mlcube_examples
-git fetch origin pull/xxx/head:feature/gpu_example && git checkout feature/gpu_example
+git fetch origin pull/68/head:feature/gpu_example && git checkout feature/gpu_example
 cd ./gpu_example/
 ```
 

--- a/gpus/check_gpus.sh
+++ b/gpus/check_gpus.sh
@@ -14,5 +14,6 @@ while [ $# -gt 0 ]; do
 done
 
 echo "CUDA_VISIBLE_DEVICES $CUDA_VISIBLE_DEVICES" |& tee "$LOG_DIR/gpus.log"
+echo "NVIDIA_VISIBLE_DEVICES $NVIDIA_VISIBLE_DEVICES" |& tee "$LOG_DIR/gpus.log"
 nvidia-smi |& tee -a "$LOG_DIR/gpus.log"
 nvidia-smi --query-gpu=gpu_name,uuid --format=csv |& tee -a "$LOG_DIR/gpus.log"

--- a/gpus/check_gpus.sh
+++ b/gpus/check_gpus.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+LOG_DIR=${LOG_DIR:-"/"}
+
+# Handle MLCube parameters
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --log_dir=*)
+        LOG_DIR="${1#*=}"
+        ;;
+    *) ;;
+    esac
+    shift
+done
+
+echo "CUDA_VISIBLE_DEVICES $CUDA_VISIBLE_DEVICES" |& tee "$LOG_DIR/train_console.log"
+nvidia-smi |& tee -a "$LOG_DIR/train_console.log"

--- a/gpus/check_gpus.sh
+++ b/gpus/check_gpus.sh
@@ -13,5 +13,6 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-echo "CUDA_VISIBLE_DEVICES $CUDA_VISIBLE_DEVICES" |& tee "$LOG_DIR/train_console.log"
-nvidia-smi |& tee -a "$LOG_DIR/train_console.log"
+echo "CUDA_VISIBLE_DEVICES $CUDA_VISIBLE_DEVICES" |& tee "$LOG_DIR/gpus.log"
+nvidia-smi |& tee -a "$LOG_DIR/gpus.log"
+nvidia-smi --query-gpu=gpu_name,uuid --format=csv |& tee -a "$LOG_DIR/gpus.log"

--- a/gpus/mlcube.yaml
+++ b/gpus/mlcube.yaml
@@ -14,7 +14,7 @@ docker:
   # Docker file name within docker build context, default is `Dockerfile`.
   build_file: "Dockerfile"
   # GPU arguments
-  gpu_args: "--gpus=all"
+  gpu_args: "--gpus=1"
 
 tasks:
   check_gpus:

--- a/gpus/mlcube.yaml
+++ b/gpus/mlcube.yaml
@@ -1,0 +1,24 @@
+name: check_gpus
+description: Check gpus example
+authors:
+  - { name: "MLCommons Best Practices Working Group" }
+
+platform:
+  accelerator_count: 1
+
+docker:
+  # Image name.
+  image: dfjbtest/gpus_example:0.0.1
+  # Docker build context relative to $MLCUBE_ROOT. Default is `build`.
+  build_context: "./"
+  # Docker file name within docker build context, default is `Dockerfile`.
+  build_file: "Dockerfile"
+  # GPU arguments
+  gpu_args: "--gpus=all"
+
+tasks:
+  check_gpus:
+    entrypoint: ./check_gpus.sh -a
+    parameters:
+      outputs:
+        log_dir: logs/

--- a/gpus/mlcube.yaml
+++ b/gpus/mlcube.yaml
@@ -18,7 +18,7 @@ docker:
 
 tasks:
   check_gpus:
-    entrypoint: ./check_gpus.sh -a
+    entrypoint: ./check_gpus.sh
     parameters:
       outputs:
         log_dir: logs/


### PR DESCRIPTION
# GPUs example

NOTE: This example depends on: [MLCUBE PR 345](https://github.com/mlcommons/mlcube/pull/345)

## Project setup

An important requirement is that you must have Docker and/or Singularity installed.

```bash
# Create Python environment and install MLCube with runners 
virtualenv -p python3 ./env && source ./env/bin/activate && pip install mlcube-docker mlcube-singularity
# Fetch the gpus example from GitHub
git clone https://github.com/mlcommons/mlcube_examples && cd ./mlcube_examples
git fetch origin pull/68/head:feature/gpu_example && git checkout feature/gpu_example
cd ./gpus/
```

## MLCube tasks

There is only one taks that will output the variable `CUDA_VISIBLE_DEVICES` along with the ouput of the `nvidia-smi` command:

```shell
mlcube run --task=check_gpus
```

You can modify the number of gpus by editing the number of `accelerator_count` inside the **mlcube.yaml** file.

Also you can override the number of gpus to use by using the `--gpus` flag when running the command, example:

```shell
mlcube run --task=check_gpus --gpus=2
```

### Singularity

For running on Singularity, you can define the platform while running the command as follows:

```shell
mlcube run --task=check_gpus --platform=singularity
```
